### PR TITLE
Fix interrupt_jarvis config issue & add client id to config

### DIFF
--- a/command_modules/spotify_module.py
+++ b/command_modules/spotify_module.py
@@ -1,11 +1,12 @@
 import random
 import spotipy
 from spotipy.oauth2 import SpotifyPKCE
+from config import SPOTIFY_CLIENT_ID
 
 # Authenticate using PKCE
 sp = spotipy.Spotify(auth_manager=SpotifyPKCE(
-    client_id="816bdceb410e4bb5b16ef27d7ae4b362", 
-    redirect_uri="http://localhost:8888/callback",
+    client_id=SPOTIFY_CLIENT_ID, 
+    redirect_uri="http://127.0.0.1:8888/callback",
     scope="user-modify-playback-state,user-read-playback-state,user-top-read",
     cache_path=".spotify_cache.json"  # Store token locally
 ))

--- a/config.ini
+++ b/config.ini
@@ -4,9 +4,13 @@ base_dir = C:\Jarvis-Mark-II
 api_key = your_api_key
 voice_key = HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Speech\Voices\Tokens\MSTTS_V110_enGB_GeorgeM
 personality = jarvis
+interrupt_jarvis = true
 
 [Gemini]
 model = gemini-2.0-flash
+
+[InputListener]
+talk_key = t
 
 [Vosk]
 model_path = vosk-model-small-en-us-0.15
@@ -22,13 +26,12 @@ port = 4455
 password = password
 websocket_library = obsws-python
 
+[Spotify]
+client_id = 816bdceb410e4bb5b16ef27d7ae4b362
+
 [Sounds]
 sounds_dir = sounds
 
 [Music]
 music_dir = music
-
-[InputListener]
-talk_key = t
-interrupt_jarvis = true
 

--- a/config.py
+++ b/config.py
@@ -48,6 +48,9 @@ default_config = {
         'password': 'password',
         'websocket_library': 'obsws-python'
     },
+    'Spotify': {
+        'client_id': '816bdceb410e4bb5b16ef27d7ae4b362'
+    },
     'Sounds': {
         'sounds_dir': 'sounds'
     },
@@ -84,8 +87,9 @@ API_KEY = config['General']['api_key']
 VOICE_KEY = config['General']['voice_key']
 PERSONALITY = config.get('General', 'personality', fallback='jarvis')
 GEMINI_MODEL = config.get('Gemini', 'model', fallback='gemini-2.0-flash')
+SPOTIFY_CLIENT_ID = config['Spotify']['client_id']
 INPUT_START_KEY = config['InputListener']['talk_key']
-INTERRUPT_JARVIS = config['InputListener']['interrupt_jarvis'] == 'true'
+INTERRUPT_JARVIS = config['General']['interrupt_jarvis']
 VOSK_MODEL_PATH = os.path.join(BASE_DIR, config['Vosk']['model_path'])
 SPEECH_ENGINE = config['Speech']['engine'].lower()
 VB_CABLE = config.getboolean('Speech', 'vb_cable', fallback=False)


### PR DESCRIPTION
- Fixes issue with the interrupt_jarvis config option, as the default config in config.py put it in general, but it was being grabbed from InputListener since thats where it was in the config.ini of the fork
- Added spotify client id to config.ini to allow users to use their own spotify apps